### PR TITLE
small formulation chage

### DIFF
--- a/entity-framework/core/managing-schemas/migrations/index.md
+++ b/entity-framework/core/managing-schemas/migrations/index.md
@@ -14,7 +14,7 @@ ms.locfileid: "34754508"
 ---
 <a name="migrations"></a>Migrationen
 ==========
-Migrationen stellen eine Möglichkeit dar, Schemaänderungen schrittweise auf die Datenbank anzuwenden, um diese mit Ihrem EF Core-Modell zu synchronisieren und gleichzeitig vorhandene Daten in der Datenbank zu speichern.
+Migrationen stellen eine Möglichkeit dar, Schemaänderungen schrittweise auf die Datenbank anzuwenden, um diese mit Ihrem EF Core-Modell zu synchronisieren und gleichzeitig vorhandene Daten in der Datenbank zu erhalten.
 
 <a name="creating-the-database"></a>Erstellen der Datenbank
 ---------------------


### PR DESCRIPTION
The old sentence literary means "...and **also** save existing Data in the Database."
>Migrationen stellen eine Möglichkeit dar, Schemaänderungen schrittweise auf die Datenbank anzuwenden, um diese mit Ihrem EF Core-Modell zu synchronisieren und gleichzeitig vorhandene Daten in der Datenbank zu speichern.

But the original documentation say that you preserve your existing data instead of just save them. That is what my suggestion says.

>Migrationen stellen eine Möglichkeit dar, Schemaänderungen schrittweise auf die Datenbank anzuwenden, um diese mit Ihrem EF Core-Modell zu synchronisieren und gleichzeitig vorhandene Daten in der Datenbank zu **erhalten.**

It is really just a small improvement/suggestion.